### PR TITLE
meta-quanta : gis: oem sensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,112 @@
+cmake_minimum_required (VERSION 2.8.10 FATAL_ERROR)
+set (BUILD_SHARED_LIBRARIES OFF)
+include (ExternalProject)
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (
+    CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -lstdc++fs \
+    -Werror \
+    -Wall \
+    -Wextra \
+    -Wnon-virtual-dtor \
+    -Wold-style-cast \
+    -Wcast-align \
+    -Wunused \
+    -Woverloaded-virtual \
+    -Wpedantic \
+    -Wmisleading-indentation \
+    -Wduplicated-cond \
+    -Wduplicated-branches \
+    -Wlogical-op \
+    -Wnull-dereference \
+    -Wuseless-cast \
+    -Wdouble-promotion \
+    -Wformat=2 \
+    -Wno-sign-compare \
+    -Wno-reorder \
+"
+)
+# todo: get rid of nos, add the below:
+#  -Wshadow \
+#  -Wconversion \
+
+set (CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+
+option (YOCTO "Enable Building in Yocto" OFF)
+option (HUNTER_ENABLED "Enable hunter package pulling" OFF)
+
+option (DISABLE_OEM "Disable installing OEM sensor" OFF)
+
+include ("cmake/HunterGate.cmake")
+
+huntergate (URL "https://github.com/ruslo/hunter/archive/v0.18.64.tar.gz" SHA1
+            "baf9c8cc4f65306f0e442b5419967b4c4c04589a")
+
+project (sensors CXX)
+
+set (OEM_SRC_FILES src/Utils.cpp src/OEMSensor.cpp)
+
+set (EXTERNAL_PACKAGES Boost sdbusplus-project)
+set (SENSOR_LINK_LIBS -lsystemd stdc++fs sdbusplus)
+
+if (NOT YOCTO)
+    option (ENABLE_TEST "Enable Google Test" OFF)
+    include_directories (SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/include/non-yocto)
+
+    externalproject_add (
+        Boost URL
+        https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+        URL_MD5 d275cd85b00022313c171f602db59fc5 SOURCE_DIR
+        "${CMAKE_BINARY_DIR}/boost-src" BINARY_DIR
+        "${CMAKE_BINARY_DIR}/boost-build" CONFIGURE_COMMAND "" BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+    )
+    include_directories (SYSTEM ${CMAKE_BINARY_DIR}/boost-src)
+    set (CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/boost-src ${CMAKE_PREFIX_PATH})
+
+    # requires apt install autoconf-archive and autoconf
+    externalproject_add (sdbusplus-project PREFIX
+                         ${CMAKE_BINARY_DIR}/sdbusplus-project GIT_REPOSITORY
+                         https://github.com/openbmc/sdbusplus.git SOURCE_DIR
+                         ${CMAKE_BINARY_DIR}/sdbusplus-src BINARY_DIR
+                         ${CMAKE_BINARY_DIR}/sdbusplus-build CONFIGURE_COMMAND
+                         "" BUILD_COMMAND cd ${CMAKE_BINARY_DIR}/sdbusplus-src
+                         && ./bootstrap.sh && ./configure --enable-transaction
+                         && make -j libsdbusplus.la INSTALL_COMMAND ""
+                         LOG_DOWNLOAD ON)
+    include_directories (SYSTEM ${CMAKE_BINARY_DIR}/sdbusplus-src)
+    link_directories (${CMAKE_BINARY_DIR}/sdbusplus-src/.libs)
+endif ()
+
+add_definitions (-DBOOST_ERROR_CODE_HEADER_ONLY)
+add_definitions (-DBOOST_SYSTEM_NO_DEPRECATED)
+add_definitions (-DBOOST_ALL_NO_LIB)
+add_definitions (-DBOOST_NO_RTTI)
+add_definitions (-DBOOST_NO_TYPEID)
+add_definitions (-DBOOST_ASIO_DISABLE_THREADS)
+
+link_directories (${EXTERNAL_INSTALL_LOCATION}/lib)
+
+include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+
+add_executable (oemsensor src/OEMSensorMain.cpp ${OEM_SRC_FILES})
+add_dependencies (oemsensor sdbusplus-project)
+target_link_libraries (oemsensor ${SENSOR_LINK_LIBS})
+target_link_libraries (oemsensor i2c)
+
+if (NOT YOCTO)
+    add_dependencies (oemsensor ${EXTERNAL_PACKAGES})
+endif ()
+
+set (SERVICE_FILE_SRC_DIR ${PROJECT_SOURCE_DIR}/service_files)
+set (SERVICE_FILE_INSTALL_DIR /lib/systemd/system/)
+
+if (NOT DISABLE_OEM)
+    install (TARGETS oemsensor DESTINATION bin)
+    install (FILES
+                 ${SERVICE_FILE_SRC_DIR}/xyz.openbmc_project.oemsensor.service
+                 DESTINATION ${SERVICE_FILE_INSTALL_DIR})
+endif ()
+

--- a/cmake-format.json
+++ b/cmake-format.json
@@ -1,0 +1,13 @@
+{
+  "enum_char": ".",
+  "line_ending": "unix",
+  "bullet_char": "*",
+  "max_subargs_per_line": 99,
+  "command_case": "lower",
+  "tab_size": 4,
+  "line_width": 80,
+  "separate_fn_name_with_space": true,
+  "dangle_parens": true,
+  "separate_ctrl_name_with_space": true
+}
+

--- a/cmake/Finddbus.cmake
+++ b/cmake/Finddbus.cmake
@@ -1,0 +1,61 @@
+# - Try to find DBus
+# Once done, this will define
+#
+#  DBUS_FOUND - system has DBus
+#  DBUS_INCLUDE_DIRS - the DBus include directories
+#  DBUS_LIBRARIES - link these to use DBus
+#
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FIND_PACKAGE(PkgConfig)
+PKG_CHECK_MODULES(PC_DBUS QUIET dbus-1)
+
+FIND_LIBRARY(DBUS_LIBRARIES
+    NAMES dbus-1
+    HINTS ${PC_DBUS_LIBDIR}
+          ${PC_DBUS_LIBRARY_DIRS}
+)
+
+message("DBUS_LIBRARIES = ${DBUS_LIBRARIES}")
+
+FIND_PATH(DBUS_INCLUDE_DIR
+    NAMES dbus/dbus.h
+    HINTS ${PC_DBUS_INCLUDEDIR}
+          ${PC_DBUS_INCLUDE_DIRS}
+)
+
+GET_FILENAME_COMPONENT(_DBUS_LIBRARY_DIR ${DBUS_LIBRARIES} PATH)
+FIND_PATH(DBUS_ARCH_INCLUDE_DIR
+    NAMES dbus/dbus-arch-deps.h
+    HINTS ${PC_DBUS_INCLUDEDIR}
+          ${PC_DBUS_INCLUDE_DIRS}
+          ${_DBUS_LIBRARY_DIR}
+          ${DBUS_INCLUDE_DIR}
+    PATH_SUFFIXES include
+)
+
+SET(DBUS_INCLUDE_DIRS ${DBUS_INCLUDE_DIR} ${DBUS_ARCH_INCLUDE_DIR})
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(DBUS REQUIRED_VARS DBUS_INCLUDE_DIRS DBUS_LIBRARIES)

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -1,0 +1,514 @@
+# Copyright (c) 2013-2015, Ruslan Baratov
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a gate file to Hunter package manager.
+# Include this file using `include` command and add package you need, example:
+#
+#     cmake_minimum_required(VERSION 3.0)
+#
+#     include("cmake/HunterGate.cmake")
+#     HunterGate(
+#         URL "https://github.com/path/to/hunter/archive.tar.gz"
+#         SHA1 "798501e983f14b28b10cda16afa4de69eee1da1d"
+#     )
+#
+#     project(MyProject)
+#
+#     hunter_add_package(Foo)
+#     hunter_add_package(Boo COMPONENTS Bar Baz)
+#
+# Projects:
+#     * https://github.com/hunter-packages/gate/
+#     * https://github.com/ruslo/hunter
+
+option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+if(HUNTER_ENABLED)
+  if(CMAKE_VERSION VERSION_LESS "3.0")
+    message(FATAL_ERROR "At least CMake version 3.0 required for hunter dependency management."
+      " Update CMake or set HUNTER_ENABLED to OFF.")
+  endif()
+endif()
+
+include(CMakeParseArguments) # cmake_parse_arguments
+
+option(HUNTER_STATUS_PRINT "Print working status" ON)
+option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
+
+set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+
+function(hunter_gate_status_print)
+  foreach(print_message ${ARGV})
+    if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+      message(STATUS "[hunter] ${print_message}")
+    endif()
+  endforeach()
+endfunction()
+
+function(hunter_gate_status_debug)
+  foreach(print_message ${ARGV})
+    if(HUNTER_STATUS_DEBUG)
+      string(TIMESTAMP timestamp)
+      message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
+    endif()
+  endforeach()
+endfunction()
+
+function(hunter_gate_wiki wiki_page)
+  message("------------------------------ WIKI -------------------------------")
+  message("    ${HUNTER_WIKI}/${wiki_page}")
+  message("-------------------------------------------------------------------")
+  message("")
+  message(FATAL_ERROR "")
+endfunction()
+
+function(hunter_gate_internal_error)
+  message("")
+  foreach(print_message ${ARGV})
+    message("[hunter ** INTERNAL **] ${print_message}")
+  endforeach()
+  message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_wiki("error.internal")
+endfunction()
+
+function(hunter_gate_fatal_error)
+  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
+  string(COMPARE EQUAL "${hunter_WIKI}" "" have_no_wiki)
+  if(have_no_wiki)
+    hunter_gate_internal_error("Expected wiki")
+  endif()
+  message("")
+  foreach(x ${hunter_UNPARSED_ARGUMENTS})
+    message("[hunter ** FATAL ERROR **] ${x}")
+  endforeach()
+  message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_wiki("${hunter_WIKI}")
+endfunction()
+
+function(hunter_gate_user_error)
+  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+endfunction()
+
+function(hunter_gate_self root version sha1 result)
+  string(COMPARE EQUAL "${root}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("root is empty")
+  endif()
+
+  string(COMPARE EQUAL "${version}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("version is empty")
+  endif()
+
+  string(COMPARE EQUAL "${sha1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("sha1 is empty")
+  endif()
+
+  string(SUBSTRING "${sha1}" 0 7 archive_id)
+
+  if(EXISTS "${root}/cmake/Hunter")
+    set(hunter_self "${root}")
+  else()
+    set(
+        hunter_self
+        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+    )
+  endif()
+
+  set("${result}" "${hunter_self}" PARENT_SCOPE)
+endfunction()
+
+# Set HUNTER_GATE_ROOT cmake variable to suitable value.
+function(hunter_gate_detect_root)
+  # Check CMake variable
+  string(COMPARE NOTEQUAL "${HUNTER_ROOT}" "" not_empty)
+  if(not_empty)
+    set(HUNTER_GATE_ROOT "${HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by cmake variable")
+    return()
+  endif()
+
+  # Check environment variable
+  string(COMPARE NOTEQUAL "$ENV{HUNTER_ROOT}" "" not_empty)
+  if(not_empty)
+    set(HUNTER_GATE_ROOT "$ENV{HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by environment variable")
+    return()
+  endif()
+
+  # Check HOME environment variable
+  string(COMPARE NOTEQUAL "$ENV{HOME}" "" result)
+  if(result)
+    set(HUNTER_GATE_ROOT "$ENV{HOME}/.hunter" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT set using HOME environment variable")
+    return()
+  endif()
+
+  # Check SYSTEMDRIVE and USERPROFILE environment variable (windows only)
+  if(WIN32)
+    string(COMPARE NOTEQUAL "$ENV{SYSTEMDRIVE}" "" result)
+    if(result)
+      set(HUNTER_GATE_ROOT "$ENV{SYSTEMDRIVE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using SYSTEMDRIVE environment variable"
+      )
+      return()
+    endif()
+
+    string(COMPARE NOTEQUAL "$ENV{USERPROFILE}" "" result)
+    if(result)
+      set(HUNTER_GATE_ROOT "$ENV{USERPROFILE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using USERPROFILE environment variable"
+      )
+      return()
+    endif()
+  endif()
+
+  hunter_gate_fatal_error(
+      "Can't detect HUNTER_ROOT"
+      WIKI "error.detect.hunter.root"
+  )
+endfunction()
+
+macro(hunter_gate_lock dir)
+  if(NOT HUNTER_SKIP_LOCK)
+    if("${CMAKE_VERSION}" VERSION_LESS "3.2")
+      hunter_gate_fatal_error(
+          "Can't lock, upgrade to CMake 3.2 or use HUNTER_SKIP_LOCK"
+          WIKI "error.can.not.lock"
+      )
+    endif()
+    hunter_gate_status_debug("Locking directory: ${dir}")
+    file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
+    hunter_gate_status_debug("Lock done")
+  endif()
+endmacro()
+
+function(hunter_gate_download dir)
+  string(
+      COMPARE
+      NOTEQUAL
+      "$ENV{HUNTER_DISABLE_AUTOINSTALL}"
+      ""
+      disable_autoinstall
+  )
+  if(disable_autoinstall AND NOT HUNTER_RUN_INSTALL)
+    hunter_gate_fatal_error(
+        "Hunter not found in '${dir}'"
+        "Set HUNTER_RUN_INSTALL=ON to auto-install it from '${HUNTER_GATE_URL}'"
+        "Settings:"
+        "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
+        "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
+        WIKI "error.run.install"
+    )
+  endif()
+  string(COMPARE EQUAL "${dir}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("Empty 'dir' argument")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_SHA1 empty")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_URL empty")
+  endif()
+
+  set(done_location "${dir}/DONE")
+  set(sha1_location "${dir}/SHA1")
+
+  set(build_dir "${dir}/Build")
+  set(cmakelists "${dir}/CMakeLists.txt")
+
+  hunter_gate_lock("${dir}")
+  if(EXISTS "${done_location}")
+    # while waiting for lock other instance can do all the job
+    hunter_gate_status_debug("File '${done_location}' found, skip install")
+    return()
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(MAKE_DIRECTORY "${build_dir}") # check directory permissions
+
+  # Disabling languages speeds up a little bit, reduces noise in the output
+  # and avoids path too long windows error
+  file(
+      WRITE
+      "${cmakelists}"
+      "cmake_minimum_required(VERSION 3.0)\n"
+      "project(HunterDownload LANGUAGES NONE)\n"
+      "include(ExternalProject)\n"
+      "ExternalProject_Add(\n"
+      "    Hunter\n"
+      "    URL\n"
+      "    \"${HUNTER_GATE_URL}\"\n"
+      "    URL_HASH\n"
+      "    SHA1=${HUNTER_GATE_SHA1}\n"
+      "    DOWNLOAD_DIR\n"
+      "    \"${dir}\"\n"
+      "    SOURCE_DIR\n"
+      "    \"${dir}/Unpacked\"\n"
+      "    CONFIGURE_COMMAND\n"
+      "    \"\"\n"
+      "    BUILD_COMMAND\n"
+      "    \"\"\n"
+      "    INSTALL_COMMAND\n"
+      "    \"\"\n"
+      ")\n"
+  )
+
+  if(HUNTER_STATUS_DEBUG)
+    set(logging_params "")
+  else()
+    set(logging_params OUTPUT_QUIET)
+  endif()
+
+  hunter_gate_status_debug("Run generate")
+
+  # Need to add toolchain file too.
+  # Otherwise on Visual Studio + MDD this will fail with error:
+  # "Could not find an appropriate version of the Windows 10 SDK installed on this machine"
+  if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+  else()
+    # 'toolchain_arg' can't be empty
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=")
+  endif()
+
+  execute_process(
+      COMMAND "${CMAKE_COMMAND}" "-H${dir}" "-B${build_dir}" "-G${CMAKE_GENERATOR}" "${toolchain_arg}"
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Configure project failed")
+  endif()
+
+  hunter_gate_status_print(
+      "Initializing Hunter workspace (${HUNTER_GATE_SHA1})"
+      "  ${HUNTER_GATE_URL}"
+      "  -> ${dir}"
+  )
+  execute_process(
+      COMMAND "${CMAKE_COMMAND}" --build "${build_dir}"
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Build project failed")
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(WRITE "${sha1_location}" "${HUNTER_GATE_SHA1}")
+  file(WRITE "${done_location}" "DONE")
+
+  hunter_gate_status_debug("Finished")
+endfunction()
+
+# Must be a macro so master file 'cmake/Hunter' can
+# apply all variables easily just by 'include' command
+# (otherwise PARENT_SCOPE magic needed)
+macro(HunterGate)
+  if(HUNTER_GATE_DONE)
+    # variable HUNTER_GATE_DONE set explicitly for external project
+    # (see `hunter_download`)
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+
+  # First HunterGate command will init Hunter, others will be ignored
+  get_property(_hunter_gate_done GLOBAL PROPERTY HUNTER_GATE_DONE SET)
+
+  if(NOT HUNTER_ENABLED)
+    # Empty function to avoid error "unknown function"
+    function(hunter_add_package)
+    endfunction()
+  elseif(_hunter_gate_done)
+    hunter_gate_status_debug("Secondary HunterGate (use old settings)")
+    hunter_gate_self(
+        "${HUNTER_CACHED_ROOT}"
+        "${HUNTER_VERSION}"
+        "${HUNTER_SHA1}"
+        _hunter_self
+    )
+    include("${_hunter_self}/cmake/Hunter")
+  else()
+    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+
+    string(COMPARE NOTEQUAL "${PROJECT_NAME}" "" _have_project_name)
+    if(_have_project_name)
+      hunter_gate_fatal_error(
+          "Please set HunterGate *before* 'project' command. "
+          "Detected project: ${PROJECT_NAME}"
+          WIKI "error.huntergate.before.project"
+      )
+    endif()
+
+    cmake_parse_arguments(
+        HUNTER_GATE "LOCAL" "URL;SHA1;GLOBAL;FILEPATH" "" ${ARGV}
+    )
+
+    string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" _empty_sha1)
+    string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" _empty_url)
+    string(
+        COMPARE
+        NOTEQUAL
+        "${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+        ""
+        _have_unparsed
+    )
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_GLOBAL}" "" _have_global)
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_FILEPATH}" "" _have_filepath)
+
+    if(_have_unparsed)
+      hunter_gate_user_error(
+          "HunterGate unparsed arguments: ${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+      )
+    endif()
+    if(_empty_sha1)
+      hunter_gate_user_error("SHA1 suboption of HunterGate is mandatory")
+    endif()
+    if(_empty_url)
+      hunter_gate_user_error("URL suboption of HunterGate is mandatory")
+    endif()
+    if(_have_global)
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has GLOBAL)")
+      endif()
+      if(_have_filepath)
+        hunter_gate_user_error("Unexpected FILEPATH (already has GLOBAL)")
+      endif()
+    endif()
+    if(HUNTER_GATE_LOCAL)
+      if(_have_global)
+        hunter_gate_user_error("Unexpected GLOBAL (already has LOCAL)")
+      endif()
+      if(_have_filepath)
+        hunter_gate_user_error("Unexpected FILEPATH (already has LOCAL)")
+      endif()
+    endif()
+    if(_have_filepath)
+      if(_have_global)
+        hunter_gate_user_error("Unexpected GLOBAL (already has FILEPATH)")
+      endif()
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has FILEPATH)")
+      endif()
+    endif()
+
+    hunter_gate_detect_root() # set HUNTER_GATE_ROOT
+
+    # Beautify path, fix probable problems with windows path slashes
+    get_filename_component(
+        HUNTER_GATE_ROOT "${HUNTER_GATE_ROOT}" ABSOLUTE
+    )
+    hunter_gate_status_debug("HUNTER_ROOT: ${HUNTER_GATE_ROOT}")
+    if(NOT HUNTER_ALLOW_SPACES_IN_PATH)
+      string(FIND "${HUNTER_GATE_ROOT}" " " _contain_spaces)
+      if(NOT _contain_spaces EQUAL -1)
+        hunter_gate_fatal_error(
+            "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
+            "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
+            "(Use at your own risk!)"
+            WIKI "error.spaces.in.hunter.root"
+        )
+      endif()
+    endif()
+
+    string(
+        REGEX
+        MATCH
+        "[0-9]+\\.[0-9]+\\.[0-9]+[-_a-z0-9]*"
+        HUNTER_GATE_VERSION
+        "${HUNTER_GATE_URL}"
+    )
+    string(COMPARE EQUAL "${HUNTER_GATE_VERSION}" "" _is_empty)
+    if(_is_empty)
+      set(HUNTER_GATE_VERSION "unknown")
+    endif()
+
+    hunter_gate_self(
+        "${HUNTER_GATE_ROOT}"
+        "${HUNTER_GATE_VERSION}"
+        "${HUNTER_GATE_SHA1}"
+        _hunter_self
+    )
+
+    set(_master_location "${_hunter_self}/cmake/Hunter")
+    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
+      # Hunter downloaded manually (e.g. by 'git clone')
+      set(_unused "xxxxxxxxxx")
+      set(HUNTER_GATE_SHA1 "${_unused}")
+      set(HUNTER_GATE_VERSION "${_unused}")
+    else()
+      get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
+      set(_done_location "${_archive_id_location}/DONE")
+      set(_sha1_location "${_archive_id_location}/SHA1")
+
+      # Check Hunter already downloaded by HunterGate
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_download("${_archive_id_location}")
+      endif()
+
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_internal_error("hunter_gate_download failed")
+      endif()
+
+      if(NOT EXISTS "${_sha1_location}")
+        hunter_gate_internal_error("${_sha1_location} not found")
+      endif()
+      file(READ "${_sha1_location}" _sha1_value)
+      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+      if(NOT _is_equal)
+        hunter_gate_internal_error(
+            "Short SHA1 collision:"
+            "  ${_sha1_value} (from ${_sha1_location})"
+            "  ${HUNTER_GATE_SHA1} (HunterGate)"
+        )
+      endif()
+      if(NOT EXISTS "${_master_location}")
+        hunter_gate_user_error(
+            "Master file not found:"
+            "  ${_master_location}"
+            "try to update Hunter/HunterGate"
+        )
+      endif()
+    endif()
+    include("${_master_location}")
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+endmacro()

--- a/include/OEMSensor.hpp
+++ b/include/OEMSensor.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "Utils.hpp"
+
+#include <boost/container/flat_map.hpp>
+#include <filesystem>
+#include <fstream>
+#include <sdbusplus/asio/object_server.hpp>
+#include <string>
+
+struct OEMInfo
+{
+    OEMInfo(const std::string& iface, const std::string& property,
+            const std::string& ptype, const std::string& dfvalue) :
+        iface(iface), property(property), ptype(ptype), dfvalue(dfvalue) 
+    {
+    }
+    std::string iface;
+    std::string property;
+    std::string ptype;
+    std::string dfvalue;
+
+    bool operator<(const OEMInfo& rhs) const
+    {
+        return (iface < rhs.iface);
+    }
+};
+
+struct OEMConfig
+{
+    OEMConfig(const uint8_t& snrnum, const uint8_t& snrtype, const std::string& name, 
+              const std::string& monitor, const std::string& exec, 
+              const std::vector<OEMInfo>& oeminfo) :
+        snrnum(snrnum), snrtype(snrtype), name(name), monitor(monitor), exec(exec), oeminfo(std::move(oeminfo))
+    {
+    }
+    uint8_t snrnum;
+    uint8_t snrtype;
+    std::string name;
+    std::string monitor;
+    std::string exec;
+    std::vector<OEMInfo> oeminfo;
+
+    bool operator<(const OEMConfig& rhs) const
+    {
+        return (name < rhs.name);
+    }
+};
+
+class OEMSensor
+{
+  public:
+    OEMSensor(boost::asio::io_service& io,
+               std::shared_ptr<sdbusplus::asio::connection>& conn,
+               OEMConfig & sensorconfig);
+    ~OEMSensor();
+
+    static constexpr unsigned int sensorPollMs = 2000;
+
+  private:
+    boost::asio::deadline_timer waitTimer;
+    std::shared_ptr<sdbusplus::asio::connection> mDbusConn;
+    OEMConfig mSnrConfig;
+
+    void setupRead(void);
+    void handleResponse(void);
+};
+
+extern boost::container::flat_map<std::string, std::unique_ptr<OEMSensor>>
+    gOemSensors;
+
+struct CmpStr
+{
+    bool operator()(const char* a, const char* b) const
+    {
+        return std::strcmp(a, b) < 0;
+    }
+};
+
+const static boost::container::flat_map<const char*, char*, CmpStr>
+    sensorTypeToString{{{"12", "/memory"},
+                        {"19", "/criticalinterrupt"},
+                        {"15", "/posterror"},
+                        {"16", "/eventloggingdisable"},
+                        {"7", "/processor"}}};

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -1,0 +1,228 @@
+#pragma once
+#include "VariantVisitors.hpp"
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/container/flat_map.hpp>
+#include <filesystem>
+#include <iostream>
+#include <regex>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/message/types.hpp>
+
+const constexpr char* inventoryPath = "/xyz/openbmc_project/inventory";
+const constexpr char* entityManagerName = "xyz.openbmc_project.EntityManager";
+
+const std::regex illegalDbusRegex("[^A-Za-z0-9_]");
+
+using BasicVariantType =
+    std::variant<std::vector<std::string>, std::string, int64_t, uint64_t,
+                 double, int32_t, uint32_t, int16_t, uint16_t, uint8_t, bool>;
+
+using ManagedObjectType = boost::container::flat_map<
+    sdbusplus::message::object_path,
+    boost::container::flat_map<
+        std::string,
+        boost::container::flat_map<std::string, BasicVariantType>>>;
+using SensorData = boost::container::flat_map<
+    std::string, boost::container::flat_map<std::string, BasicVariantType>>;
+
+using GetSubTreeType = std::vector<
+    std::pair<std::string,
+              std::vector<std::pair<std::string, std::vector<std::string>>>>>;
+using SensorBaseConfiguration =
+    std::pair<std::string,
+              boost::container::flat_map<std::string, BasicVariantType>>;
+
+using Association = std::tuple<std::string, std::string, std::string>;
+
+bool findFiles(const std::filesystem::path dirPath,
+               const std::string& matchString,
+               std::vector<std::filesystem::path>& foundPaths,
+               unsigned int symlinkDepth = 1);
+bool isPowerOn(void);
+bool hasBiosPost(void);
+void setupPowerMatch(const std::shared_ptr<sdbusplus::asio::connection>& conn);
+bool getSensorConfiguration(
+    const std::string& type,
+    const std::shared_ptr<sdbusplus::asio::connection>& dbusConnection,
+    ManagedObjectType& resp, bool useCache = false);
+
+void createAssociation(
+    std::shared_ptr<sdbusplus::asio::dbus_interface>& association,
+    const std::string& path);
+
+// replaces limits if MinReading and MaxReading are found.
+void findLimits(std::pair<double, double>& limits,
+                const SensorBaseConfiguration* data);
+
+enum class PowerState
+{
+    on,
+    biosPost,
+    always
+};
+
+namespace mapper
+{
+constexpr const char* busName = "xyz.openbmc_project.ObjectMapper";
+constexpr const char* path = "/xyz/openbmc_project/object_mapper";
+constexpr const char* interface = "xyz.openbmc_project.ObjectMapper";
+constexpr const char* subtree = "GetSubTree";
+} // namespace mapper
+
+namespace properties
+{
+constexpr const char* interface = "org.freedesktop.DBus.Properties";
+constexpr const char* get = "Get";
+} // namespace properties
+
+namespace power
+{
+const static constexpr char* busname = "xyz.openbmc_project.State.Host";
+const static constexpr char* interface = "xyz.openbmc_project.State.Host";
+const static constexpr char* path = "/xyz/openbmc_project/state/host0";
+const static constexpr char* property = "CurrentHostState";
+} // namespace power
+namespace post
+{
+const static constexpr char* busname =
+    "xyz.openbmc_project.State.OperatingSystem";
+const static constexpr char* interface =
+    "xyz.openbmc_project.State.OperatingSystem.Status";
+const static constexpr char* path = "/xyz/openbmc_project/state/os";
+const static constexpr char* property = "OperatingSystemState";
+} // namespace post
+
+namespace association
+{
+const static constexpr char* interface =
+    "xyz.openbmc_project.Association.Definitions";
+} // namespace association
+
+template <typename T>
+inline T loadVariant(
+    const boost::container::flat_map<std::string, BasicVariantType>& data,
+    const std::string& key)
+{
+    auto it = data.find(key);
+    if (it == data.end())
+    {
+        std::cerr << "Configuration missing " << key << "\n";
+        throw std::invalid_argument("Key Missing");
+    }
+    if constexpr (std::is_same_v<T, double>)
+    {
+        return std::visit(VariantToDoubleVisitor(), it->second);
+    }
+    else if constexpr (std::is_unsigned_v<T>)
+    {
+        return std::visit(VariantToUnsignedIntVisitor(), it->second);
+    }
+    else if constexpr (std::is_same_v<T, std::string>)
+    {
+        return std::visit(VariantToStringVisitor(), it->second);
+    }
+    else
+    {
+        static_assert(!std::is_same_v<T, T>, "Type Not Implemented");
+    }
+}
+
+inline void setReadState(const std::string& str, PowerState& val)
+{
+
+    if (str == "On")
+    {
+        val = PowerState::on;
+    }
+    else if (str == "BiosPost")
+    {
+        val = PowerState::biosPost;
+    }
+    else if (str == "Always")
+    {
+        val = PowerState::always;
+    }
+}
+
+void createInventoryAssoc(
+    std::shared_ptr<sdbusplus::asio::connection> conn,
+    std::shared_ptr<sdbusplus::asio::dbus_interface> association,
+    const std::string& path);
+
+struct GetSensorConfiguration
+    : std::enable_shared_from_this<GetSensorConfiguration>
+{
+    GetSensorConfiguration(
+        std::shared_ptr<sdbusplus::asio::connection> connection,
+        std::function<void(ManagedObjectType& resp)>&& callbackFunc) :
+        dbusConnection(connection),
+        callback(std::move(callbackFunc))
+    {
+    }
+    void getConfiguration(const std::vector<std::string>& interfaces)
+    {
+        std::shared_ptr<GetSensorConfiguration> self = shared_from_this();
+        dbusConnection->async_method_call(
+            [self, interfaces](const boost::system::error_code ec,
+                               const GetSubTreeType& ret) {
+                if (ec)
+                {
+                    std::cerr << "Error calling mapper\n";
+                    return;
+                }
+                for (const auto& [path, objDict] : ret)
+                {
+                    if (objDict.empty())
+                    {
+                        return;
+                    }
+                    const std::string& owner = objDict.begin()->first;
+
+                    for (const std::string& interface : objDict.begin()->second)
+                    {
+                        // anything that starts with a requested configuration
+                        // is good
+                        if (std::find_if(
+                                interfaces.begin(), interfaces.end(),
+                                [interface](const std::string& possible) {
+                                    return boost::starts_with(interface,
+                                                              possible);
+                                }) == interfaces.end())
+                        {
+                            continue;
+                        }
+
+                        self->dbusConnection->async_method_call(
+                            [self, path, interface](
+                                const boost::system::error_code ec,
+                                boost::container::flat_map<
+                                    std::string, BasicVariantType>& data) {
+                                if (ec)
+                                {
+                                    std::cerr << "Error getting " << path
+                                              << "\n";
+                                    return;
+                                }
+                                self->respData[path][interface] =
+                                    std::move(data);
+                            },
+                            owner, path, "org.freedesktop.DBus.Properties",
+                            "GetAll", interface);
+                    }
+                }
+            },
+            mapper::busName, mapper::path, mapper::interface, mapper::subtree,
+            "/", 0, interfaces);
+    }
+
+    ~GetSensorConfiguration()
+    {
+        callback(respData);
+    }
+
+    std::shared_ptr<sdbusplus::asio::connection> dbusConnection;
+    std::function<void(ManagedObjectType& resp)> callback;
+    ManagedObjectType respData;
+};

--- a/include/VariantVisitors.hpp
+++ b/include/VariantVisitors.hpp
@@ -1,0 +1,90 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#pragma once
+#include <stdexcept>
+#include <string>
+#include <variant>
+
+struct VariantToFloatVisitor
+{
+
+    template <typename T>
+    float operator()(const T& t) const
+    {
+        if constexpr (std::is_arithmetic_v<T>)
+        {
+            return static_cast<float>(t);
+        }
+        throw std::invalid_argument("Cannot translate type to float");
+    }
+};
+
+struct VariantToIntVisitor
+{
+    template <typename T>
+    int operator()(const T& t) const
+    {
+        if constexpr (std::is_arithmetic_v<T>)
+        {
+            return static_cast<int>(t);
+        }
+        throw std::invalid_argument("Cannot translate type to int");
+    }
+};
+
+struct VariantToUnsignedIntVisitor
+{
+    template <typename T>
+    unsigned int operator()(const T& t) const
+    {
+        if constexpr (std::is_arithmetic_v<T>)
+        {
+            return static_cast<unsigned int>(t);
+        }
+        throw std::invalid_argument("Cannot translate type to unsigned int");
+    }
+};
+
+struct VariantToStringVisitor
+{
+    template <typename T>
+    std::string operator()(const T& t) const
+    {
+        if constexpr (std::is_same_v<T, std::string>)
+        {
+            return t;
+        }
+        else if constexpr (std::is_arithmetic_v<T>)
+        {
+            return std::to_string(t);
+        }
+        throw std::invalid_argument("Cannot translate type to string");
+    }
+};
+
+struct VariantToDoubleVisitor
+{
+    template <typename T>
+    double operator()(const T& t) const
+    {
+        if constexpr (std::is_arithmetic_v<T>)
+        {
+            return static_cast<double>(t);
+        }
+        throw std::invalid_argument("Cannot translate type to double");
+    }
+};

--- a/service_files/xyz.openbmc_project.oemsensor.service
+++ b/service_files/xyz.openbmc_project.oemsensor.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=OEM Sensor
+StopWhenUnneeded=false
+Requires=xyz.openbmc_project.EntityManager.service phosphor-ipmi-host.service
+After=xyz.openbmc_project.EntityManager.service phosphor-ipmi-host.service
+
+[Service]
+Restart=always
+RestartSec=5
+StartLimitBurst=10
+ExecStart=/usr/bin/oemsensor
+
+[Install]
+WantedBy=multi-user.target

--- a/src/OEMSensor.cpp
+++ b/src/OEMSensor.cpp
@@ -1,0 +1,121 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include <unistd.h>
+
+#include <OEMSensor.hpp>
+#include <Utils.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <iostream>
+#include <limits>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <boost/process.hpp>
+
+static constexpr bool DEBUG = false;
+
+static int executeCmd(std::string exec)
+{
+    const char *cmd = exec.c_str();
+    boost::process::child execProg(cmd);
+    execProg.wait();
+    return execProg.exit_code();
+}
+
+OEMSensor::OEMSensor(boost::asio::io_service& io,
+                       std::shared_ptr<sdbusplus::asio::connection>& conn,
+                       OEMConfig& sensorconfig) :
+    waitTimer(io), mDbusConn(conn), mSnrConfig(sensorconfig)
+{
+    setupRead();
+}
+
+OEMSensor::~OEMSensor()
+{
+    waitTimer.cancel();
+}
+
+void OEMSensor::setupRead(void)
+{
+    if (DEBUG)
+    {
+        std::cerr << "enter OEMSensor::setupRead" << "\n";
+        std::cerr << "sensor name: " << mSnrConfig.name << "\n";
+        std::cerr << "sensor num: " << static_cast<unsigned>(mSnrConfig.snrnum) << "\n";
+        std::cerr << "sensor type: " << static_cast<unsigned>(mSnrConfig.snrtype) << "\n";
+        std::cerr << "monitor: " << mSnrConfig.monitor << "\n";
+        std::cerr << "exec: " << mSnrConfig.exec << "\n";
+    }
+
+    std::string monitor = mSnrConfig.monitor;
+    std::string exec = mSnrConfig.exec;
+
+    if (monitor == "oneshot")
+    {
+        // Execute Response
+        auto retCode = executeCmd(exec);
+
+        if (0 != retCode)
+        {
+            std::cerr << "oneshot sensor: " << mSnrConfig.name  << "\n";
+            std::cerr << "exec " << exec << " failed !"  << "\n";
+        }
+    }
+
+    handleResponse();
+}
+
+void OEMSensor::handleResponse()
+{
+    size_t pollTime = OEMSensor::sensorPollMs;
+    waitTimer.expires_from_now(boost::posix_time::milliseconds(pollTime));
+    waitTimer.async_wait([&](const boost::system::error_code& ec) {
+        // case of timer expired
+        if (!ec)
+        {
+            std::string monitor = mSnrConfig.monitor;
+            std::string exec = mSnrConfig.exec;
+            if (DEBUG)
+            {
+                std::cerr << "monitor: " << monitor << "\n";
+                std::cerr << "exec: " << exec << "\n";
+            }
+
+            if (monitor != "oneshot")
+            {
+                // Execute Response
+                auto retCode = executeCmd(exec);
+
+                if (0 != retCode)
+                {
+                    std::cerr << "polling sensor: " << mSnrConfig.name  << "\n";
+                    std::cerr << "exec " << exec << " failed !"  << "\n";
+                }
+            }
+
+            // trigger next polling
+            handleResponse();
+        }
+        // case of being canceled
+        else if (ec == boost::asio::error::operation_aborted)
+        {
+            std::cerr << "Timer of oem sensor is cancelled. Return \n";
+            return;
+        }
+    });
+}

--- a/src/OEMSensorMain.cpp
+++ b/src/OEMSensorMain.cpp
@@ -1,0 +1,319 @@
+/*
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+/      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include <fcntl.h>
+
+#include <OEMSensor.hpp>
+#include <Utils.hpp>
+#include <VariantVisitors.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/container/flat_set.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/process/child.hpp>
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <boost/asio.hpp>
+#include <chrono>
+#include <ctime>
+#include <iostream>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/asio/sd_event.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/exception.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdbusplus/timer.hpp>
+
+static constexpr bool DEBUG = false;
+
+boost::container::flat_map<std::string, std::unique_ptr<OEMSensor>> gOemSensors;
+namespace fs = std::filesystem;
+
+static constexpr const char* configPrefix =
+    "xyz.openbmc_project.Configuration.";
+static constexpr std::array<const char*, 1> sensorTypes = {"Oem"};
+static constexpr const char* sensorType =
+    "xyz.openbmc_project.Configuration.OEMSensor";
+
+bool getOemConfig(
+    const std::shared_ptr<sdbusplus::asio::connection>& systemBus,
+    boost::container::flat_set<OEMConfig>& oemConfigs,
+    ManagedObjectType& sensorConfigs,
+    sdbusplus::asio::object_server& objectServer,
+    boost::container::flat_map<
+        std::string, std::shared_ptr<sdbusplus::asio::dbus_interface>>&
+        sensorIfaces)
+{
+    bool useCache = false;
+    sensorConfigs.clear();
+
+    // use new data the first time, then refresh
+    for (const char* type : sensorTypes)
+    {
+        if (!getSensorConfiguration(configPrefix + std::string(type), systemBus,
+                                    sensorConfigs, useCache))
+        {
+            return false;
+        }
+
+        useCache = true;
+    }
+
+    for (const char* type : sensorTypes)
+    {
+        for (const std::pair<sdbusplus::message::object_path, SensorData>&
+                 sensor : sensorConfigs)
+        {
+            for (const SensorBaseConfiguration& config : sensor.second)
+            {
+                if ((configPrefix + std::string(type)) != config.first)
+                {
+                    continue;
+                }
+
+                auto findName = config.second.find("Name");
+                if (findName == config.second.end())
+                {
+                    continue;
+                }
+                std::string nameRaw =
+                    std::visit(VariantToStringVisitor(), findName->second);
+                std::string name =
+                    std::regex_replace(nameRaw, illegalDbusRegex, "_");
+
+                auto findSnrNum = config.second.find("SnrNum");
+                if (findSnrNum == config.second.end())
+                {
+                    std::cerr << "Can't find 'SnrNum' setting in " << name << "\n";
+                    continue;
+                }
+                uint64_t snrnum = std::visit(VariantToUnsignedIntVisitor(), 
+				                             findSnrNum->second);
+
+                auto findSnrType = config.second.find("SnrType");
+                if (findSnrType == config.second.end())
+                {
+                    std::cerr << "Can't find 'SnrType' setting in " << name << "\n";
+                    continue;
+                }
+                uint64_t snrtype = std::visit(VariantToUnsignedIntVisitor(),
+                                              findSnrType->second);
+                std::string sensortypestr = std::to_string(static_cast<unsigned>(snrtype));
+                auto findMonitor = config.second.find("Monitor");
+                std::string monitor = "NA";
+                std::string exec = "NA";
+                if (findMonitor == config.second.end())
+                {
+                    std::cerr << "Can't find 'Monitor' setting in " << name << "\n";
+                    std::cerr << "Set 'Monitor' and 'Exec' as 'NA'" << "\n";
+                }
+                else
+                {
+                    monitor = std::visit(VariantToStringVisitor(), findMonitor->second);
+                    if (monitor == "oneshot" || monitor == "polling")
+                    {
+                        auto findExec = config.second.find("Exec");
+                        if (findExec == config.second.end())
+                        {
+                            std::cerr << "Can't find 'Exec' setting in " << name << "\n";
+                            continue;
+                        }
+                        exec = std::visit(VariantToStringVisitor(), findExec->second);
+                    }
+                    else
+                    {
+                        std::cerr << "Incorrect 'Monitor' setting in " << name << "\n";
+                        continue;
+                    }
+                }
+
+                std::vector<OEMInfo> oeminfoVector;
+                boost::container::flat_map<std::string, std::vector<OEMInfo>> ifaceList;
+                std::string OemIface = "";
+                std::string OemProperty = "";
+                std::string OemPtype = "";
+                std::string OemDfvalue = "";
+                for (const SensorBaseConfiguration& suppConfig : sensor.second)
+                {
+                    if (suppConfig.first.find("Offset") !=
+                        std::string::npos)
+                    {
+                        auto oemSetting = suppConfig.second;
+
+                        auto findOemIface = oemSetting.find("Iface");
+                        auto findOemProperty = oemSetting.find("Property");
+                        auto findOemPtype = oemSetting.find("Ptype");
+                        auto findOemDfvalue = oemSetting.find("Dfvalue");
+
+                        if (findOemIface == oemSetting.end() ||
+                            findOemProperty == oemSetting.end() ||
+                            findOemPtype == oemSetting.end() ||
+                            findOemDfvalue == oemSetting.end())
+                        {
+                            std::cerr << "Incorrect OEM configuration setting\n";
+                            break;
+                        }
+
+                        OemIface = std::visit(VariantToStringVisitor(), findOemIface->second);
+                        OemPtype = std::visit(VariantToStringVisitor(), findOemPtype->second);
+                        OemProperty = std::visit(VariantToStringVisitor(), findOemProperty->second);
+                        OemDfvalue = std::visit(VariantToStringVisitor(), findOemDfvalue->second);
+                        auto findSensor = sensorTypeToString.find(sensortypestr.c_str());
+                        if (findSensor != sensorTypeToString.end())
+                            {
+                                sensortypestr = findSensor->second;
+                            } // elselse default 0x0 RESERVED
+
+                        if (DEBUG)
+                        {
+                            std::cerr << "snrnum: " << static_cast<unsigned>(snrnum) << "\n";
+                            std::cerr << "snrtype: " << static_cast<unsigned>(snrtype) << "\n";
+                            std::cerr << "name: " << name << "\n";
+                            std::cerr << "iface: " << OemIface << "\n";
+                            std::cerr << "property: " << OemProperty << "\n";
+                            std::cerr << "ptype: " << OemPtype << "\n";
+                            std::cerr << "dfvalue: " << OemDfvalue << "\n";
+                            std::cerr << "monitor: " << monitor << "\n";
+                            std::cerr << "exec: " << exec << "\n";
+                            std::cerr << "type: " << type << "\n";
+                            std::cerr << "sensortypestr: " << sensortypestr << "\n";
+                        }
+
+                        oeminfoVector.emplace_back(OemIface, OemProperty, OemPtype, OemDfvalue);
+                        ifaceList[OemIface].emplace_back(OemIface, OemProperty, OemPtype, OemDfvalue);
+                    }
+                }
+                auto ifacename = name + "_" + OemIface;
+                if (sensorIfaces.find(ifacename) == sensorIfaces.end())
+                {
+                    for (auto& oemEvt : ifaceList)
+                    {
+                        auto iface = objectServer.add_interface(
+                                    "/xyz/openbmc_project/OEMSensor" + sensortypestr + std::string("/") + name,
+                                    oemEvt.first);
+                        for (auto& oemsetting : oemEvt.second)
+                        {
+                            const auto property = oemsetting.property;
+                            if (oemsetting.ptype == "bool")
+                            {
+                                bool value = false;
+                                auto dfvalue = oemsetting.dfvalue; 
+                            
+                                if (dfvalue == "1")							
+                                {
+                                    value = true;
+                                }
+                                iface->register_property(property, value,
+                                                         sdbusplus::asio::PropertyPermission::readWrite);
+                            } 
+                            else if (oemsetting.ptype == "string")
+                            {
+                                auto value = oemsetting.dfvalue;
+                                iface->register_property(property, value,
+                                                         sdbusplus::asio::PropertyPermission::readWrite);
+                            }
+                        }
+                        iface->initialize();
+                        sensorIfaces[ifacename] = std::move(iface);
+                    }
+                }
+
+                oemConfigs.emplace(snrnum, snrtype, name, monitor, exec, oeminfoVector);
+            }
+        }
+    }
+
+    if (oemConfigs.size())
+    {
+        std::cerr << "OEM config" << (oemConfigs.size() == 1 ? " is" : "s are")
+                  << " parsed\n";
+        std::cerr << "OEM config size is " << oemConfigs.size() << "\n";
+
+        return true;
+    }
+
+    std::cerr << "oemConfigs is NULL\n";
+    return false;
+}
+
+void detectOEMSensor(boost::asio::io_service& io,
+                     std::shared_ptr<sdbusplus::asio::connection>& systemBus,
+                     boost::container::flat_set<OEMConfig>& oemConfigs)
+{
+    for (auto& oemsensor : oemConfigs)
+    {
+        if (oemsensor.monitor != "NA")
+        {
+            gOemSensors[oemsensor.name] = std::make_unique<OEMSensor>(io, systemBus, oemsensor);
+        }
+    }
+
+    if (gOemSensors.size())
+    {
+        std::cerr << "Total number of OEM sensors for monitoring is " << oemConfigs.size() << "\n";
+    }
+    else
+    {
+        std::cerr << "No OEM sensors need to be monitored" << "\n";
+    }
+}
+
+int main()
+{
+    boost::asio::io_service io;
+    auto systemBus = std::make_shared<sdbusplus::asio::connection>(io);
+    boost::container::flat_set<OEMConfig> oemConfigs;
+    systemBus->request_name("xyz.openbmc_project.OEMSensor");
+    sdbusplus::asio::object_server objectServer(systemBus);
+    std::vector<std::unique_ptr<sdbusplus::bus::match::match>> matches;
+    boost::asio::deadline_timer pingTimer(io);
+    boost::asio::deadline_timer creationTimer(io);
+    boost::asio::deadline_timer filterTimer(io);
+    ManagedObjectType sensorConfigs;
+    boost::container::flat_map<std::string,
+                               std::shared_ptr<sdbusplus::asio::dbus_interface>>
+        sensorIfaces;
+
+    if (getOemConfig(systemBus, oemConfigs, sensorConfigs, objectServer, sensorIfaces))
+    {
+        detectOEMSensor(io, systemBus, oemConfigs);
+    }
+    // callback to handle configuration change
+    std::function<void(sdbusplus::message::message&)> eventHandler =
+        [&](sdbusplus::message::message& message) {
+            if (message.is_method_error())
+            {
+                std::cerr << "callback method error\n";
+                return;
+            }
+
+            std::cerr << "rescan due to configuration change \n";
+            if (getOemConfig(systemBus, oemConfigs, sensorConfigs, objectServer, sensorIfaces))
+            {
+                detectOEMSensor(io, systemBus, oemConfigs);
+            }
+        };
+
+    auto match = std::make_unique<sdbusplus::bus::match::match>(
+        static_cast<sdbusplus::bus::bus&>(*systemBus),
+        "type='signal',member='PropertiesChanged',path_namespace='" +
+            std::string(inventoryPath) + "',arg0namespace='" + sensorType + "'",
+          eventHandler);
+    io.run();
+    return 0;
+}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,0 +1,308 @@
+/*
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+#include <Utils.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <filesystem>
+#include <fstream>
+#include <regex>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+namespace fs = std::filesystem;
+
+static bool powerStatusOn = false;
+static bool biosHasPost = false;
+
+static std::unique_ptr<sdbusplus::bus::match::match> powerMatch = nullptr;
+static std::unique_ptr<sdbusplus::bus::match::match> postMatch = nullptr;
+
+bool getSensorConfiguration(
+    const std::string& type,
+    const std::shared_ptr<sdbusplus::asio::connection>& dbusConnection,
+    ManagedObjectType& resp, bool useCache)
+{
+    static ManagedObjectType managedObj;
+
+    if (!useCache)
+    {
+        managedObj.clear();
+        sdbusplus::message::message getManagedObjects =
+            dbusConnection->new_method_call(
+                entityManagerName, "/", "org.freedesktop.DBus.ObjectManager",
+                "GetManagedObjects");
+        bool err = false;
+        try
+        {
+            sdbusplus::message::message reply =
+                dbusConnection->call(getManagedObjects);
+            reply.read(managedObj);
+        }
+        catch (const sdbusplus::exception::exception& e)
+        {
+            std::cerr << "While calling GetManagedObjects on service:"
+                      << entityManagerName << " exception name:" << e.name()
+                      << "and description:" << e.description()
+                      << " was thrown\n";
+            err = true;
+        }
+
+        if (err)
+        {
+            std::cerr << "Error communicating to entity manager\n";
+            return false;
+        }
+    }
+    for (const auto& pathPair : managedObj)
+    {
+        bool correctType = false;
+        for (const auto& entry : pathPair.second)
+        {
+            if (boost::starts_with(entry.first, type))
+            {
+                correctType = true;
+                break;
+            }
+        }
+        if (correctType)
+        {
+            resp.emplace(pathPair);
+        }
+    }
+    return true;
+}
+
+bool findFiles(const fs::path dirPath, const std::string& matchString,
+               std::vector<fs::path>& foundPaths, unsigned int symlinkDepth)
+{
+    if (!fs::exists(dirPath))
+        return false;
+
+    std::regex search(matchString);
+    std::smatch match;
+    for (auto& p : fs::recursive_directory_iterator(dirPath))
+    {
+        std::string path = p.path().string();
+        if (!is_directory(p))
+        {
+            if (std::regex_search(path, match, search))
+                foundPaths.emplace_back(p.path());
+        }
+        else if (is_symlink(p) && symlinkDepth)
+        {
+            findFiles(p.path(), matchString, foundPaths, symlinkDepth - 1);
+        }
+    }
+    return true;
+}
+
+bool isPowerOn(void)
+{
+    if (!powerMatch)
+    {
+        throw std::runtime_error("Power Match Not Created");
+    }
+    return powerStatusOn;
+}
+
+bool hasBiosPost(void)
+{
+    if (!postMatch)
+    {
+        throw std::runtime_error("Post Match Not Created");
+    }
+    return biosHasPost;
+}
+
+void setupPowerMatch(const std::shared_ptr<sdbusplus::asio::connection>& conn)
+{
+    static boost::asio::steady_timer timer(conn->get_io_context());
+    // create a match for powergood changes, first time do a method call to
+    // cache the correct value
+    if (powerMatch)
+    {
+        return;
+    }
+
+    powerMatch = std::make_unique<sdbusplus::bus::match::match>(
+        static_cast<sdbusplus::bus::bus&>(*conn),
+        "type='signal',interface='" + std::string(properties::interface) +
+            "',path='" + std::string(power::path) + "',arg0='" +
+            std::string(power::interface) + "'",
+        [](sdbusplus::message::message& message) {
+            std::string objectName;
+            boost::container::flat_map<std::string, std::variant<std::string>>
+                values;
+            message.read(objectName, values);
+            auto findState = values.find(power::property);
+            if (findState != values.end())
+            {
+                bool on = boost::ends_with(
+                    std::get<std::string>(findState->second), "Running");
+                if (!on)
+                {
+                    timer.cancel();
+                    powerStatusOn = false;
+                    return;
+                }
+                // on comes too quickly
+                timer.expires_after(std::chrono::seconds(10));
+                timer.async_wait([](boost::system::error_code ec) {
+                    if (ec == boost::asio::error::operation_aborted)
+                    {
+                        return;
+                    }
+                    else if (ec)
+                    {
+                        std::cerr << "Timer error " << ec.message() << "\n";
+                        return;
+                    }
+                    powerStatusOn = true;
+                });
+            }
+        });
+
+    postMatch = std::make_unique<sdbusplus::bus::match::match>(
+        static_cast<sdbusplus::bus::bus&>(*conn),
+        "type='signal',interface='" + std::string(properties::interface) +
+            "',path='" + std::string(post::path) + "',arg0='" +
+            std::string(post::interface) + "'",
+        [](sdbusplus::message::message& message) {
+            std::string objectName;
+            boost::container::flat_map<std::string, std::variant<std::string>>
+                values;
+            message.read(objectName, values);
+            auto findState = values.find(post::property);
+            if (findState != values.end())
+            {
+                biosHasPost =
+                    std::get<std::string>(findState->second) != "Inactive";
+            }
+        });
+
+    conn->async_method_call(
+        [](boost::system::error_code ec,
+           const std::variant<std::string>& state) {
+            if (ec)
+            {
+                // we commonly come up before power control, we'll capture the
+                // property change later
+                return;
+            }
+            powerStatusOn =
+                boost::ends_with(std::get<std::string>(state), "Running");
+        },
+        power::busname, power::path, properties::interface, properties::get,
+        power::interface, power::property);
+
+    conn->async_method_call(
+        [](boost::system::error_code ec,
+           const std::variant<std::string>& state) {
+            if (ec)
+            {
+                // we commonly come up before power control, we'll capture the
+                // property change later
+                return;
+            }
+            biosHasPost = std::get<std::string>(state) != "Inactive";
+        },
+        post::busname, post::path, properties::interface, properties::get,
+        post::interface, post::property);
+}
+
+// replaces limits if MinReading and MaxReading are found.
+void findLimits(std::pair<double, double>& limits,
+                const SensorBaseConfiguration* data)
+{
+    if (!data)
+    {
+        return;
+    }
+    auto maxFind = data->second.find("MaxReading");
+    auto minFind = data->second.find("MinReading");
+
+    if (minFind != data->second.end())
+    {
+        limits.first = std::visit(VariantToDoubleVisitor(), minFind->second);
+    }
+    if (maxFind != data->second.end())
+    {
+        limits.second = std::visit(VariantToDoubleVisitor(), maxFind->second);
+    }
+}
+
+void createAssociation(
+    std::shared_ptr<sdbusplus::asio::dbus_interface>& association,
+    const std::string& path)
+{
+    if (association)
+    {
+        std::filesystem::path p(path);
+
+        std::vector<Association> associations;
+        associations.push_back(
+            Association("chassis", "all_sensors", p.parent_path().string()));
+        association->register_property("Associations", associations);
+        association->initialize();
+    }
+}
+
+void setInventoryAssociation(
+    std::shared_ptr<sdbusplus::asio::dbus_interface> association,
+    const std::string& path, const std::string& chassisPath)
+{
+    if (association)
+    {
+        std::filesystem::path p(path);
+
+        std::vector<Association> associations;
+        associations.push_back(
+            Association("inventory", "sensors", p.parent_path().string()));
+        associations.push_back(
+            Association("chassis", "all_sensors", chassisPath));
+        association->register_property("Associations", associations);
+        association->initialize();
+    }
+}
+
+void createInventoryAssoc(
+    std::shared_ptr<sdbusplus::asio::connection> conn,
+    std::shared_ptr<sdbusplus::asio::dbus_interface> association,
+    const std::string& path)
+{
+    if (!association)
+    {
+        return;
+    }
+    conn->async_method_call(
+        [association, path](const boost::system::error_code ec,
+                            const std::vector<std::string>& ret) {
+            if (ec)
+            {
+                std::cerr << "Error calling mapper\n";
+                return;
+            }
+            for (const auto& object : ret)
+            {
+                setInventoryAssociation(association, path, object);
+            }
+        },
+        mapper::busName, mapper::path, mapper::interface, "GetSubTreePaths",
+        "/xyz/openbmc_project/inventory/system", 2,
+        std::array<std::string, 1>{
+            "xyz.openbmc_project.Inventory.Item.System"});
+}


### PR DESCRIPTION
Use this package and entity manager configuration to generate quanata
bios sensors object path and interfaces under xyz.openbmc_project.OEMSensor
and sel-logger can generate correct sensor type log for bios sensors.

Signed-off-by: Duke Du <Duke.Du@quantatw.com>