### PR TITLE
add new OEMSensor type & change obj path for new OEMSensor type.

### DIFF
--- a/include/OEMSensor.hpp
+++ b/include/OEMSensor.hpp
@@ -82,4 +82,7 @@ const static boost::container::flat_map<const char*, char*, CmpStr>
                         {"19", "/criticalinterrupt"},
                         {"15", "/posterror"},
                         {"16", "/eventloggingdisable"},
-                        {"7", "/processor"}}};
+                        {"7", "/processor"},
+                        {"40", "/utilization"}, /*managementsubsystemhealth*/
+                        {"111", "/oem"} /*managementsubsystemhealth*/
+                      }};


### PR DESCRIPTION
1. add new OEMSensor type, utiliztion and oem.
2. change new oem type utilization and oem, obj path, this will match Redfish rules to generate the sensors.